### PR TITLE
Fix stop_webui signature

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -922,7 +922,7 @@ class Api:
             restart.restart_program()
         return Response(status_code=501)
 
-    def stop_webui(request):
+    def stop_webui(self):
         shared.state.server_command = "stop"
         return Response("Stopping.")
 


### PR DESCRIPTION
## Summary
- correct stop_webui to accept self instead of request
- ensure router uses the corrected method

## Testing
- `python -m py_compile modules/api/api.py`
